### PR TITLE
Remove redundant urcu.h and resource.h includes

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -55,11 +55,9 @@
 #include <limits.h>
 #include <float.h>
 #include <math.h>
-#include <sys/resource.h>
 #include <sys/utsname.h>
 #include <locale.h>
 #include <sys/socket.h>
-#include <urcu.h>
 
 /* Our shared "common" objects */
 


### PR DESCRIPTION
Found that <urcu.h> and <sys/resource.h> were included twice in src/server.c. Since the headers have guards, this is harmless but redundant. Removed the second inclusion for cleanliness, and duplicate inclusion can also increase compilation time.